### PR TITLE
Fix handling of empty CalendarEventArray in GetUserAvailabilityResponse.

### DIFF
--- a/src/js/Core/Responses/AttendeeAvailability.ts
+++ b/src/js/Core/Responses/AttendeeAvailability.ts
@@ -28,6 +28,7 @@ export class AttendeeAvailability extends ServiceResponse {
                     break;
                 case XmlElementNames.CalendarEventArray:
                     var calendarEventArray = jsObject[key];
+                    if (!calendarEventArray) break;
                     var calendarEvents:any[] = calendarEventArray[XmlElementNames.CalendarEvent];
                     if (!Array.isArray(calendarEvents)) {
                         calendarEvents = [calendarEvents]


### PR DESCRIPTION
First of all, thanks for the great library! I ran into a bug in the GetUserAvailability response handling, so I figured it would be useful to push it back upstream ...

[`CalendarEventArray`](https://msdn.microsoft.com/en-us/library/office/aa564344(v=exchg.150).aspx) can have no child elements if there are no events to return in the response. This PR handles that case.

_**As a side note**: When there is a bug such as this one, the response handling fails with an uncaught exception/rejection with very little useful information: `The request failed. undefined`. This is a separate issue of its own, as there should not be any uncaught exceptions/rejections, as the caller gets no feedback, and makes is very hard to debug._