### PR TITLE
Make sure we reject promise with an Error object

### DIFF
--- a/src/js/XHRDefault.ts
+++ b/src/js/XHRDefault.ts
@@ -52,7 +52,7 @@ export class XHRDefault implements IXHRApi {
 						resolve(setupXhrResponse(xhrResponse));
 					}
 					else {
-						reject(setupXhrResponse(xhrResponse));
+						reject(new Error("Error status: " + xhrResponse.status));
 					}
 				}
 			});


### PR DESCRIPTION
In the case of an error returned from O365 (non 200 status) it was rejected with the xhrResponse object which is not a proper Error object. I've made a suggested change to create an Error object with the status code in it.
We had issues with our service hanging with unresolved promised after a period of time.