### PR TITLE
fixing an empty fieldURI related soap error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ews-javascript-api",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "EWS Managed api in JavaScript",
   "main": "js/ExchangeWebService.js",
   "scripts": {

--- a/src/js/Core/PropertySet.ts
+++ b/src/js/Core/PropertySet.ts
@@ -320,7 +320,10 @@ export class PropertySet implements ISelfValidate, IEnumerable<PropertyDefinitio
 
         if (argsLength > 2) {
             for (var _i = 2; _i < arguments.length; _i++) {
-                additionalProperties.push(arguments[_i]);
+                let argument = arguments[_i];
+                if (argument.uri) {
+                    additionalProperties.push(argument);
+                }
             }
         }
 


### PR DESCRIPTION
I came across an error while using this library (thanks for the great work btw).
It had to do with empty `<fieldURI/>` parameters in the SOAP request. Those triggered "missing required fieldURI attribute" errors.
This commit fixes the bug for me so I figured I'd contribute