### PR TITLE
Fixes #298: Initialise entry to an object, not null.

### DIFF
--- a/src/js/ComplexProperties/EmailAddressDictionary.ts
+++ b/src/js/ComplexProperties/EmailAddressDictionary.ts
@@ -75,7 +75,7 @@ export class EmailAddressDictionary extends DictionaryProperty<EmailAddressKey, 
      * @return  {boolean}                  true if the Dictionary contains an e-mail address associated with the specified key; otherwise, false.
      */
     TryGetValue(key: EmailAddressKey, emailAddress: IOutParam<EmailAddress>): boolean {
-        let entry: IOutParam<EmailAddressEntry> = null;
+        let entry: IOutParam<EmailAddressEntry> = { outValue: null };
 
         if (this.Entries.tryGetValue(key, entry)) {
             emailAddress.outValue = entry.outValue.EmailAddress;


### PR DESCRIPTION
As described in https://github.com/gautamsi/ews-javascript-api/issues/298, this PR prevents an exception from being thrown when using EmailAddressDictionary::TryGetValue by initialising the `entry` variable as an object.