### PR TITLE
release 0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ews-javascript-api",
-  "version": "0.9.6-dev.1",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ews-javascript-api",
-  "version": "0.9.6",
+  "version": "0.9.7-dev.1",
   "description": "EWS Managed api in JavaScript",
   "main": "js/ExchangeWebService.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ews-javascript-api",
-  "version": "0.9.7-dev.1",
+  "version": "0.9.7-dev.2",
   "description": "EWS Managed api in JavaScript",
   "main": "js/ExchangeWebService.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ews-javascript-api",
-  "version": "0.9.7-dev.2",
+  "version": "0.10.0",
   "description": "EWS Managed api in JavaScript",
   "main": "js/ExchangeWebService.js",
   "scripts": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -100,6 +100,7 @@ function copyPackageJson() {
     const file = 'package.json'
     const obj = await readFile(file).catch(error => console.error(error));
     delete obj.devDependencies;
+    delete obj.scripts;
     await writeFile(`${outputDir}/package.json`, obj, { spaces: 4, EOL: os.EOL }).catch(error => console.error(error));
     resolve();
   });

--- a/src/js/Autodiscover/Requests/AutodiscoverRequest.ts
+++ b/src/js/Autodiscover/Requests/AutodiscoverRequest.ts
@@ -155,7 +155,7 @@ export abstract class AutodiscoverRequest {
       }
 
       EwsLogging.DebugLog("sending ews request");
-      EwsLogging.DebugLog(xhrOptions, true);
+      EwsLogging.DebugLog({ ...xhrOptions, ...{ headers: { ...xhrOptions.headers, Authorization: "REDACTED" } }}, true);
       const xhrResponse = await this.service.XHRApi.xhr(xhrOptions)
       const ewsXmlReader = new EwsXmlReader(xhrResponse.responseText || xhrResponse.response);
       const responseObject = ewsXmlReader.JsObject;

--- a/src/js/Core/ExchangeServiceBase.ts
+++ b/src/js/Core/ExchangeServiceBase.ts
@@ -753,24 +753,24 @@ export abstract class ExchangeServiceBase {
     //todo: implement tracing
     this.TraceHttpResponseHeaders(traceType, response);
 
-    this.SaveHttpResponseHeaders(response.getAllResponseHeaders());
+    this.SaveHttpResponseHeaders(response);
   }
 
   /**
    * Save the HTTP response headers.
    *
-   * @param   {Object}   headers   The response headers
+   * @param   {Object}   response   The response headers
    */
-  private SaveHttpResponseHeaders(headers: any/* System.Net.WebHeaderCollection*/): any {
+  private SaveHttpResponseHeaders(response: any/* System.Net.WebHeaderCollection*/): any {
     //debug:
     this.httpResponseHeaders.clear();
 
-    for (var key in headers.headers) {
-      this.httpResponseHeaders.Add(key, headers.headers[key]);
+    for (var key in response.headers || {}) {
+      this.httpResponseHeaders.Add(key, response.headers[key]);
     }
 
     if (this.OnResponseHeadersCaptured != null) {
-      this.OnResponseHeadersCaptured(headers);
+      this.OnResponseHeadersCaptured(this.httpResponseHeaders);
     }
   }
 

--- a/src/js/Core/ExchangeServiceBase.ts
+++ b/src/js/Core/ExchangeServiceBase.ts
@@ -72,7 +72,7 @@ export abstract class ExchangeServiceBase {
   private clientRequestId: string = null;
   private returnClientRequestId: boolean = false;
   // private cookieContainer: CookieContainer = new CookieContainer();
-  protected timeZone: TimeZoneInfo = null;
+  protected timeZone: TimeZoneInfo = TimeZoneInfo.Local;
   private timeZoneDefinition: TimeZoneDefinition = null;
   private serverInfo: ExchangeServerInfo = null;
   // private webProxy: IWebProxy = null;
@@ -445,9 +445,12 @@ export abstract class ExchangeServiceBase {
       }
     }
 
-
-
     this.requestedServerVersion = requestedServerVersion;
+
+    if (hasValue(timeZone)) {
+      this.timeZone = timeZone;
+      //this.useDefaultCredentials = true; //ref: no default credential in node.js
+    }
 
     if (hasValue(service)) {
       // this.useDefaultCredentials = service.useDefaultCredentials;
@@ -466,11 +469,6 @@ export abstract class ExchangeServiceBase {
       this.httpHeaders = service.httpHeaders;
       // this.ewsHttpWebRequestFactory = service.ewsHttpWebRequestFactory;
       this.xhrApi = service.xhrApi;
-    }
-
-    if (timeZone !== null && typeof timeZone !== 'undefined') {
-      this.timeZone = timeZone;
-      //this.useDefaultCredentials = true; //ref: no default credential in node.js
     }
   }
   //#endregion
@@ -713,18 +711,18 @@ export abstract class ExchangeServiceBase {
     }
 
     // REF: no default credential in NodeJs
-    //request.UseDefaultCredentials = this.UseDefaultCredentials;
+    // request.UseDefaultCredentials = this.UseDefaultCredentials;
     // if (!this.UseDefaultCredentials) {
-    //   var serviceCredentials = this.Credentials;
-    //   if (serviceCredentials === null) {
-    //     throw new ServiceLocalException(Strings.CredentialsRequired);
-    //   }
+    var serviceCredentials = this.Credentials;
+    if (serviceCredentials === null) {
+      throw new ServiceLocalException(Strings.CredentialsRequired);
+    }
 
-    //   // Make sure that credentials have been authenticated if required
-    //   //serviceCredentials.PreAuthenticate(); //todo: fix preauthenticate if possible
+    // Make sure that credentials have been authenticated if required
+    //serviceCredentials.PreAuthenticate(); //todo: fix preauthenticate if possible
 
-    //   // Apply credentials to the request
-    //   serviceCredentials.PrepareWebRequest(request);
+    // Apply credentials to the request
+    serviceCredentials.PrepareWebRequest(request);
     // }
     // else
     //     debugger;
@@ -749,8 +747,7 @@ export abstract class ExchangeServiceBase {
    * @param   {XMLHttpRequest}   response    The response.
    */
   ProcessHttpResponseHeaders(traceType: TraceFlags, response: XMLHttpRequest): void {
-    return;
-    //todo: implement tracing
+    //TODO: implement tracing properly
     this.TraceHttpResponseHeaders(traceType, response);
 
     this.SaveHttpResponseHeaders(response);

--- a/src/js/Core/ExchangeServiceBase.ts
+++ b/src/js/Core/ExchangeServiceBase.ts
@@ -371,24 +371,24 @@ export abstract class ExchangeServiceBase {
   //#region Constructor
 
   /**
-   * @internal Initializes a new instance of the **ExchangeServiceBase** class.
+   * Initializes a new instance of the **ExchangeServiceBase** class.
    *
    */
   constructor();
   /**
-   * @internal Initializes a new instance of the **ExchangeServiceBase** class.
+   * Initializes a new instance of the **ExchangeServiceBase** class.
    *
    * @param   {TimeZoneInfo}   timeZone   The time zone to which the service is scoped.
    */
   constructor(timeZone: TimeZoneInfo);
   /**
-   * @internal Initializes a new instance of the **ExchangeServiceBase** class.
+   * Initializes a new instance of the **ExchangeServiceBase** class.
    *
    * @param   {ExchangeVersion}   requestedServerVersion   The requested server version.
    */
   constructor(requestedServerVersion: ExchangeVersion);
   /**
-   * @internal Initializes a new instance of the **ExchangeServiceBase** class.
+   * Initializes a new instance of the **ExchangeServiceBase** class.
    *
    * @param   {ExchangeVersion}   requestedServerVersion   The requested server version.
    * @param   {TimeZoneInfo}      timeZone                 The time zone to which the service is scoped.

--- a/src/js/Core/Requests/HangingServiceRequestBase.ts
+++ b/src/js/Core/Requests/HangingServiceRequestBase.ts
@@ -368,7 +368,7 @@ export class HangingServiceRequestBase extends ServiceRequestBase {
         //var startTime = Date.now();// DateTime.UtcNow;
         //var response = XHR(request);
         EwsLogging.DebugLog("sending ews request");
-        EwsLogging.DebugLog(request, true);
+        EwsLogging.DebugLog({ ...request, ...{ headers: { ...request.headers, Authorization: "REDACTED" } }}, true);
 
         return this.Service.XHRApi.xhrStream(request, progressDelegate);
         // return new Promise((successDelegate, errorDelegate) => {

--- a/src/js/Core/Requests/ServiceRequestBase.ts
+++ b/src/js/Core/Requests/ServiceRequestBase.ts
@@ -488,7 +488,7 @@ export abstract class ServiceRequestBase {
         //var startTime = Date.now();// DateTime.UtcNow;
         //var response = XHR(request);
         EwsLogging.DebugLog("sending ews request");
-        EwsLogging.DebugLog(request, true);
+        EwsLogging.DebugLog({ ...request, ...{ headers: { ...request.headers, Authorization: "REDACTED" } }}, true);
 
         return this.service.XHRApi.xhr(request);
 

--- a/src/js/Core/Requests/SimpleServiceRequestBase.ts
+++ b/src/js/Core/Requests/SimpleServiceRequestBase.ts
@@ -50,7 +50,7 @@ export class SimpleServiceRequestBase extends ServiceRequestBase {
 
                         var ewsXmlReader: EwsServiceXmlReader = new EwsServiceXmlReader(xhrResponse.responseText || xhrResponse.response, this.Service);
                         //EwsLogging.DebugLog(ewsXmlReader.JsObject, true);
-                        var serviceResponse = this.ReadResponsePrivate(ewsXmlReader.JsObject);
+                        var serviceResponse = this.ReadResponsePrivate(xhrResponse, ewsXmlReader.JsObject);
 
                         if (successDelegate)
                             successDelegate(serviceResponse || xhrResponse.responseText || xhrResponse.response);
@@ -73,7 +73,7 @@ export class SimpleServiceRequestBase extends ServiceRequestBase {
         });
 
     }
-    private ReadResponsePrivate(response: any /*IEwsHttpWebResponse*/): any {
+    private ReadResponsePrivate(response: any /*IEwsHttpWebResponse*/, jsObject: any): any {
         var serviceResponse: any;
 
         try {
@@ -107,10 +107,10 @@ export class SimpleServiceRequestBase extends ServiceRequestBase {
 
 
                 if (this.Service.RenderingMethod == RenderingMode.Xml) {
-                    serviceResponse = this.ReadResponseXmlJsObject(response);
+                    serviceResponse = this.ReadResponseXmlJsObject(jsObject);
                 }
                 else if (this.Service.RenderingMethod == RenderingMode.JSON) {
-                    serviceResponse = this.ReadResponseJson(response);
+                    serviceResponse = this.ReadResponseJson(jsObject);
                 }
                 else {
                     throw new Error/*InvalidOperationException*/("Unknown RenderingMethod.");

--- a/src/js/Core/ServiceObjects/Items/Item.ts
+++ b/src/js/Core/ServiceObjects/Items/Item.ts
@@ -1,6 +1,6 @@
 ﻿import { AffectedTaskOccurrence } from "../../../Enumerations/AffectedTaskOccurrence";
 import { ArchiveTag } from "../../../ComplexProperties/ArchiveTag";
-import { ArrayHelper, StringHelper } from "../../../ExtensionMethods";
+import { ArrayHelper, StringHelper, isNullOrUndefined } from "../../../ExtensionMethods";
 import { Attachment } from "../../../ComplexProperties/Attachment";
 import { AttachmentCollection } from "../../../ComplexProperties/AttachmentCollection";
 import { ConflictResolutionMode } from "../../../Enumerations/ConflictResolutionMode";
@@ -670,7 +670,9 @@ export class Item extends ServiceObject {
      * @param   {boolean}   suppressReadReceipts   Whether to suppress read receipts
      */
     Delete(deleteMode: DeleteMode, suppressReadReceipts: boolean): Promise<void>
-    Delete(deleteMode: DeleteMode, suppressReadReceipts: boolean = false): Promise<void> { return this.InternalDelete(deleteMode, null, null, suppressReadReceipts); }
+    Delete(deleteMode: DeleteMode, suppressReadReceipts: boolean = false): Promise<void> {
+        return this.InternalDelete(deleteMode, null, null, suppressReadReceipts);
+    }
 
     /**
      * @internal Gets a list of extended properties defined on this object.
@@ -785,16 +787,14 @@ export class Item extends ServiceObject {
         this.ThrowIfThisIsAttachment();
 
         // If sendCancellationsMode is null, use the default value that's appropriate for item type.
-        // if (!sendCancellationsMode)
-        // {
-        //     sendCancellationsMode = this.DefaultSendCancellationsMode;
-        // }
+        if (isNullOrUndefined(sendCancellationsMode)) {
+            sendCancellationsMode = this.DefaultSendCancellationsMode;
+        }
 
         // If affectedTaskOccurrences is null, use the default value that's appropriate for item type.
-        // if (!affectedTaskOccurrences)
-        // {
-        //     affectedTaskOccurrences = this.DefaultAffectedTaskOccurrences;
-        // }
+        if (isNullOrUndefined(affectedTaskOccurrences)) {
+            affectedTaskOccurrences = this.DefaultAffectedTaskOccurrences;
+        }
 
         return this.Service.DeleteItem(
             this.Id,

--- a/src/js/Misc/DelegateTypes.ts
+++ b/src/js/Misc/DelegateTypes.ts
@@ -1,9 +1,10 @@
-﻿import {ItemAttachment} from "../ComplexProperties/ItemAttachment";
-import {ExchangeVersion} from "../Enumerations/ExchangeVersion";
-import {PropertyDefinition} from "../PropertyDefinitions/PropertyDefinition";
-import {ComplexProperty} from "../ComplexProperties/ComplexProperty";
-import {ExchangeService} from "../Core/ExchangeService";
-import {ServiceObject} from "../Core/ServiceObjects/ServiceObject";
+﻿import { ItemAttachment } from "../ComplexProperties/ItemAttachment";
+import { ExchangeVersion } from "../Enumerations/ExchangeVersion";
+import { PropertyDefinition } from "../PropertyDefinitions/PropertyDefinition";
+import { ComplexProperty } from "../ComplexProperties/ComplexProperty";
+import { ExchangeService } from "../Core/ExchangeService";
+import { ServiceObject } from "../Core/ServiceObjects/ServiceObject";
+import { Dictionary } from "../AltDictionary";
 
 
 //no change needed
@@ -25,7 +26,7 @@ export interface CustomXmlSerializationDelegate {
 //}
 
 export interface ResponseHeadersCapturedHandler {
-    (responseHeaders: any /*System.Net.WebHeaderCollection*/): void;
+    (responseHeaders: Dictionary<string, string>): void;
 }
 //class ResponseHeadersCapturedHandler extends System.MulticastDelegate {
 //    //BeginInvoke(responseHeaders: System.Net.WebHeaderCollection, callback: System.AsyncCallback, object: any): System.IAsyncResult{ throw new Error("DelegateTypes.ts - BeginInvoke : Not implemented.");}
@@ -66,17 +67,17 @@ export interface GetPropertyDefinitionCallback {
 export interface CreateComplexPropertyDelegate<TComplexProperty extends ComplexProperty> {
     (): TComplexProperty;
 }
-    //class GetPropertyDefinitionCallback extends System.MulticastDelegate {
-    //    //BeginInvoke(version: ExchangeVersion, callback: System.AsyncCallback, object: any): System.IAsyncResult{ throw new Error("DelegateTypes.ts - BeginInvoke : Not implemented.");}
-    //    //EndInvoke(result: System.IAsyncResult): PropertyDefinition{ throw new Error("DelegateTypes.ts - EndInvoke : Not implemented.");}
-    //    //Invoke(version: ExchangeVersion): PropertyDefinition{ throw new Error("DelegateTypes.ts - Invoke : Not implemented.");}
-    //}
+//class GetPropertyDefinitionCallback extends System.MulticastDelegate {
+//    //BeginInvoke(version: ExchangeVersion, callback: System.AsyncCallback, object: any): System.IAsyncResult{ throw new Error("DelegateTypes.ts - BeginInvoke : Not implemented.");}
+//    //EndInvoke(result: System.IAsyncResult): PropertyDefinition{ throw new Error("DelegateTypes.ts - EndInvoke : Not implemented.");}
+//    //Invoke(version: ExchangeVersion): PropertyDefinition{ throw new Error("DelegateTypes.ts - Invoke : Not implemented.");}
+//}
 
-    //class CreateComplexPropertyDelegate<TComplexProperty> extends System.MulticastDelegate {
-    //    //BeginInvoke(callback: System.AsyncCallback, object: any): System.IAsyncResult{ throw new Error("DelegateTypes.ts - BeginInvoke : Not implemented.");}
-    //    //EndInvoke(result: System.IAsyncResult): TComplexProperty{ throw new Error("DelegateTypes.ts - EndInvoke : Not implemented.");}
-    //    //Invoke(): TComplexProperty{ throw new Error("DelegateTypes.ts - Invoke : Not implemented.");}
-    //}
+//class CreateComplexPropertyDelegate<TComplexProperty> extends System.MulticastDelegate {
+//    //BeginInvoke(callback: System.AsyncCallback, object: any): System.IAsyncResult{ throw new Error("DelegateTypes.ts - BeginInvoke : Not implemented.");}
+//    //EndInvoke(result: System.IAsyncResult): TComplexProperty{ throw new Error("DelegateTypes.ts - EndInvoke : Not implemented.");}
+//    //Invoke(): TComplexProperty{ throw new Error("DelegateTypes.ts - Invoke : Not implemented.");}
+//}
 
 
 export interface CreateServiceObjectWithServiceParam {

--- a/typings/ExchangeWebService.d.ts
+++ b/typings/ExchangeWebService.d.ts
@@ -21712,7 +21712,7 @@ export interface CustomXmlSerializationDelegate {
     (writer: any): any;
 }
 export interface ResponseHeadersCapturedHandler {
-    (responseHeaders: any): void;
+    (responseHeaders: Dictionary<string, string>): void;
 }
 export interface ServiceObjectChangedDelegate {
     (serviceObject: ServiceObject): void;

--- a/typings/ExchangeWebService.d.ts
+++ b/typings/ExchangeWebService.d.ts
@@ -5339,6 +5339,30 @@ export interface EnumVersionDelegate {
      */
     readonly HttpResponseHeaders: Dictionary<string, string>;
     XHRApi: IXHRApi;
+    /**
+     * Initializes a new instance of the **ExchangeServiceBase** class.
+     *
+     */
+    constructor();
+    /**
+     * Initializes a new instance of the **ExchangeServiceBase** class.
+     *
+     * @param   {TimeZoneInfo}   timeZone   The time zone to which the service is scoped.
+     */
+    constructor(timeZone: TimeZoneInfo);
+    /**
+     * Initializes a new instance of the **ExchangeServiceBase** class.
+     *
+     * @param   {ExchangeVersion}   requestedServerVersion   The requested server version.
+     */
+    constructor(requestedServerVersion: ExchangeVersion);
+    /**
+     * Initializes a new instance of the **ExchangeServiceBase** class.
+     *
+     * @param   {ExchangeVersion}   requestedServerVersion   The requested server version.
+     * @param   {TimeZoneInfo}      timeZone                 The time zone to which the service is scoped.
+     */
+    constructor(requestedServerVersion: ExchangeVersion, timeZone: TimeZoneInfo);
 }
 /**
  * JSON names not shared with the XmlElementNames or XmlAttributeNames classes.


### PR DESCRIPTION
contain fixes for 0.10

** Breaking Changes **
* `<ExchangeService>.HttpHeaders` is now Disctionary instance, compatible with c# disctionary. you can no longer do `service.HttpHeaders[<header>] = value`. do this instead `service.HttpHeaders.Add("header", "value"); `