### PR TITLE
Update TimeZoneDefinition.ts to fallback to parsing when mapping fails

### DIFF
--- a/src/js/ComplexProperties/TimeZones/TimeZoneDefinition.ts
+++ b/src/js/ComplexProperties/TimeZones/TimeZoneDefinition.ts
@@ -290,8 +290,13 @@ export class TimeZoneDefinition extends ComplexProperty {
         this.Validate();
 
         if (!parse) {
-            //ref: skipped creation based on server data, directly creating using TimeZone Mapping data. complex to translate Windows TimeZoneInfo subclasses to javascript.
-            return TimeZoneInfo.FindSystemTimeZoneById(this.Id);
+            try {
+                //ref: skipped creation based on server data, directly creating using TimeZone Mapping data. complex to translate Windows TimeZoneInfo subclasses to javascript.
+                return TimeZoneInfo.FindSystemTimeZoneById(this.Id);
+            }
+            catch {
+                EwsLogging.DebugLog(`Could not resolve a system timezone with Id "${this.Id}"`);
+            }
         }
         let result: TimeZoneInfo;
 


### PR DESCRIPTION
Events that do not provide a standard timezone id (e.g. we see a lot of events with Id `Customized Time Zone`) currently do not provide a way to access the definition of the timezone. In this case, `TimeZone` is `Customized Time Zone` and `StartTimeZone` is `undefined`. Afaik, there is no way to access the timezone parameters.

This PR is to fallback to timezone parsing when mapping fails. @gautamsi what do you think about this?

PS: events with "Customized Time Zone" are not only edge cases. iOS creates events with this kind of timezone!