### PR TITLE
hotfix: Fix mapping WellKnownFolderName string

### DIFF
--- a/src/js/Enumerations/WellKnownFolderName.ts
+++ b/src/js/Enumerations/WellKnownFolderName.ts
@@ -242,4 +242,21 @@ export module WellKnownFolderName {
 
         return ExchangeVersion.Exchange_Version_Not_Updated;
     }
+
+    const cachedValues = Object.keys(WellKnownFolderName)
+        .filter(key => typeof WellKnownFolderName[key] == 'number')
+        .map(item => item.toLowerCase())
+        .reduce((prev, item, index) => ({...prev, [item]: index, [index]: item }), {});
+
+    /**EwsEnumAttribute */
+    export function FromEwsEnumString(value: string): any {
+        const result = cachedValues[value];
+        return result;
+    }
+
+    /**EwsEnumAttribute */
+    export function ToEwsEnumString(value: any) {
+        return WellKnownFolderName[value].toLowerCase();
+    }
+
 }


### PR DESCRIPTION
Recently I came to issue with `WellKnownFolderName` not being mapped properly by this library. It was caused by difference between response from EWS API, which uses string values and this library, which uses enum with ints.

This PR adds mapping between enum and string values so `WellKnownFolderName` is properly loaded from server response.